### PR TITLE
Add the ability to auto-determine the presenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you want to change the directory, you have two options.
 First options is to set the full namespace while you're creating the presenter class
 
 ```bash
-php artisna presneter:make App\Models\Presenter\UserPresenter
+php artisan presneter:make App\Models\Presenter\UserPresenter
 ```
 
 Or change `presenter_namespace` from `config/laravel-presenter` file.

--- a/src/Concerns/UsesPresenters.php
+++ b/src/Concerns/UsesPresenters.php
@@ -3,6 +3,7 @@
 namespace Coderflex\LaravelPresenter\Concerns;
 
 use Coderflex\LaravelPresenter\Exceptions\PresenterException;
+use Illuminate\Support\Str;
 
 /**
  * Uses Presenters Trait
@@ -61,7 +62,7 @@ trait UsesPresenters
     {
         $modelNameModifier = $type === 'default' ? '' : $type;
 
-        return str(get_class())
+        return Str::of(get_class())
             ->replace('Models', 'Presenters')
             ->append(str($modelNameModifier)->ucfirst())
             ->append('Presenter')

--- a/src/Concerns/UsesPresenters.php
+++ b/src/Concerns/UsesPresenters.php
@@ -9,18 +9,62 @@ use Coderflex\LaravelPresenter\Exceptions\PresenterException;
  */
 trait UsesPresenters
 {
+    /*
+    |--------------------------------------------------------------------------
+    | Presenters
+    |--------------------------------------------------------------------------
+    |
+    | Presenters can be defined as a single item in $this->presenter or
+    | as an array of $this->presenters. If neither are set, then we will
+    | generate a default based on the Model and type (if set).
+    |
+    */
+
     /**
-     * Check the given presenters value exists or not
-     *
-     * @param string $type
-     * @return mixed
+     * @throws PresenterException
      */
-    public function present(string $type = 'default')
+    public function present(string $type = 'default'): mixed
     {
-        if (array_key_exists($type, $this->presenters)) {
-            return new $this->presenters[$type]($this);
+        $presenter = $this->getDefaultPresenterName($type);
+
+        if (! is_null($this->presenters) && is_array($this->presenters)) {
+            if (array_key_exists($type, $this->presenters)) {
+                $presenter = $this->presenters[$type];
+            } else {
+                throw new PresenterException();
+            }
+
+        } elseif (isset($this->presenter) && is_string($this->presenter)) {
+            $presenter = $this->presenter;
+        }
+
+        if (class_exists($presenter)) {
+            return new $presenter($this);
         }
 
         throw new PresenterException();
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Presenter Names
+    |--------------------------------------------------------------------------
+    |
+    | By default, the presenter name is defined based on the name of the
+    | Model class. The default namespace is \App\Presenters. So, the Model
+    | Day has Presenter DayPresenter. However, if you supply a type, e.g. then it
+    | would be DayTypePresenter.
+    |
+    */
+
+    private function getDefaultPresenterName($type)
+    {
+        $modelNameModifier = $type === 'default' ? '' : $type;
+
+        return str(get_class())
+            ->replace('Models', 'Presenters')
+            ->append(str($modelNameModifier)->ucfirst())
+            ->append('Presenter')
+            ->toString();
     }
 }

--- a/src/Concerns/UsesPresenters.php
+++ b/src/Concerns/UsesPresenters.php
@@ -28,14 +28,14 @@ trait UsesPresenters
     {
         $presenter = $this->getDefaultPresenterName($type);
 
-        if (! is_null($this->presenters) && is_array($this->presenters)) {
-            if (array_key_exists($type, $this->presenters)) {
-                $presenter = $this->presenters[$type];
-            } else {
-                throw new PresenterException();
-            }
+        if (
+            is_array($this->presenters) &&
+            array_key_exists($type, $this->presenters ?? [])
+        ) {
+            $presenter = $this->presenters[$type];
+        }
 
-        } elseif (isset($this->presenter) && is_string($this->presenter)) {
+        if (is_string($this->presenter ?? null)) {
             $presenter = $this->presenter;
         }
 

--- a/tests/Models/Item.php
+++ b/tests/Models/Item.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Coderflex\LaravelPresenter\Tests\Models;
+
+use Coderflex\LaravelPresenter\Concerns\CanPresent;
+use Coderflex\LaravelPresenter\Concerns\UsesPresenters;
+use Illuminate\Database\Eloquent\Model;
+
+class Item extends Model implements CanPresent
+{
+    use UsesPresenters;
+
+    protected $guarded = [];
+}

--- a/tests/Presenters/ItemPresenter.php
+++ b/tests/Presenters/ItemPresenter.php
@@ -5,11 +5,12 @@ namespace Coderflex\LaravelPresenter\Tests\Presenters;
 ;
 
 use Coderflex\LaravelPresenter\Presenter;
+use Illuminate\Support\Str;
 
 class ItemPresenter extends Presenter
 {
     public function slug()
     {
-        return str($this->model->title)->slug()->toString();
+        return Str::of($this->model->title)->slug()->toString();
     }
 }

--- a/tests/Presenters/ItemPresenter.php
+++ b/tests/Presenters/ItemPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Coderflex\LaravelPresenter\Tests\Presenters;
+
+;
+
+use Coderflex\LaravelPresenter\Presenter;
+
+class ItemPresenter extends Presenter
+{
+    public function slug()
+    {
+        return str($this->model->title)->slug()->toString();
+    }
+}

--- a/tests/Presenters/ItemSubdomainPresenter.php
+++ b/tests/Presenters/ItemSubdomainPresenter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Coderflex\LaravelPresenter\Tests\Presenters;
+
+;
+
+use Coderflex\LaravelPresenter\Presenter;
+
+class ItemSubdomainPresenter extends Presenter
+{
+    public function caps()
+    {
+        return str($this->model->title)->upper()->toString();
+    }
+}

--- a/tests/Presenters/ItemSubdomainPresenter.php
+++ b/tests/Presenters/ItemSubdomainPresenter.php
@@ -5,11 +5,12 @@ namespace Coderflex\LaravelPresenter\Tests\Presenters;
 ;
 
 use Coderflex\LaravelPresenter\Presenter;
+use Illuminate\Support\Str;
 
 class ItemSubdomainPresenter extends Presenter
 {
     public function caps()
     {
-        return str($this->model->title)->upper()->toString();
+        return Str::of($this->model->title)->upper()->toString();
     }
 }

--- a/tests/PresentersTest.php
+++ b/tests/PresentersTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Coderflex\LaravelPresenter\Tests\Models\Item;
 use Coderflex\LaravelPresenter\Tests\Models\Post;
 use Coderflex\LaravelPresenter\Tests\Models\User;
 
@@ -74,3 +75,21 @@ it('should implements CanPresent Interface', function () {
     Coderflex\LaravelPresenter\Exceptions\PresenterException::class,
     'Coderflex\LaravelPresenter\Tests\Models\Post should implements \Coderflex\LaravelPresenter\Concerns\CanPresent interface'
 )->group('Presenter Implementation');
+
+it('can automatically load the presenter', function () {
+    $item = new Item([
+        'title' => 'An item title',
+    ]);
+
+    expect($item->present()->slug)
+        ->toEqual('an-item-title');
+});
+
+it('can automatically load a non-default presenter', function () {
+    $item = new Item([
+        'title' => 'An item title',
+    ]);
+
+    expect($item->present('subdomain')->caps)
+        ->toEqual('AN ITEM TITLE');
+});

--- a/tests/database/migrations/create_items_table.php.stub
+++ b/tests/database/migrations/create_items_table.php.stub
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+};


### PR DESCRIPTION
I wonder whether you'd be interested in considering this pull-request. 

The idea here is to automatically use a presenter based on naming convention. So, in the User Model, the UserPresenter is loaded without needing to specify it in the $presenters array.

It also guesses the name for a named presenter, e.g. $users->present('certificate')->title would load the UserCertificatePresenter.