### PR TITLE
Add Laravel 12.x, 13.x and PHP 8.2/8.3/8.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - laravel: 10.*
             testbench: ^8.0.0
-            carbon: ">=3.8.4"
+            carbon: "*"
           - laravel: 11.*
             testbench: ^9.0
             carbon: ">=3.8.4"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.2, 8.3, 8.4]
@@ -20,16 +20,16 @@ jobs:
         stability: [prefer-stable]
         include:
           - laravel: 10.*
-            testbench: ^8.0.0
+            testbench: 8.*
             carbon: "*"
           - laravel: 11.*
-            testbench: ^9.0
+            testbench: 9.*
             carbon: ">=3.8.4"
           - laravel: 12.*
-            testbench: ^10.0
+            testbench: 10.*
             carbon: ">=3.8.4"
           - laravel: 13.*
-            testbench: ^11.0
+            testbench: 11.*
             carbon: ">=3.8.4"
         exclude:
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,23 +15,37 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.1, 8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*, 13.*]
+        stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: ^8.0.0
+            carbon: ">=3.8.4"
           - laravel: 11.*
             testbench: ^9.0
+            carbon: ">=3.8.4"
+          - laravel: 12.*
+            testbench: ^10.0
+            carbon: ">=3.8.4"
+          - laravel: 13.*
+            testbench: ^11.0
+            carbon: ">=3.8.4"
         exclude:
           - laravel: 11.*
             php: 8.1
+          - laravel: 12.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.1
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -47,8 +61,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: List Installed Dependencies
+        run: composer show -D
+
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --ci --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -16,21 +16,21 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
+        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/console": "^8.75|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/console": "^8.75|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10|^6.1|^7.0|^8.1",
-        "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^1.22|^2.34",
-        "pestphp/pest-plugin-laravel": "^1.3|^2.3",
+        "nunomaduro/collision": "^5.10|^6.1|^7.0|^8.1|^9.0",
+        "nunomaduro/larastan": "^1.0|^2.0|^3.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^1.22|^2.34|^3.7",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.0",
         "phpstan/extension-installer": "^1.2",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0",
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "nunomaduro/larastan": "^1.0|^2.0|^3.0",
         "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^1.22|^2.34|^3.7",
-        "pestphp/pest-plugin-laravel": "^1.3|^2.3|^3.0",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
         "phpstan/phpstan-phpunit": "^1.0|^2.0",
@@ -50,7 +49,6 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin-laravel": true,
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true,
             "phpstan/phpstan-deprecation-rules": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,20 +3,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false"
     executionOrder="random"
     failOnWarning="true"
     failOnRisky="true"
     failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
 >
     <testsuites>
         <testsuite name="Coderflex Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
     backupGlobals="false"
     bootstrap="vendor/autoload.php"
     colors="true"

--- a/src/Console/PresenterMakeCommand.php
+++ b/src/Console/PresenterMakeCommand.php
@@ -6,7 +6,7 @@ class PresenterMakeCommand extends MakePresenterCommand
 {
     public $name = 'presenter:make';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setHidden(true);
     }


### PR DESCRIPTION
## Summary

- `illuminate/console` + `illuminate/contracts`: add `^13.0`
- `php`: add `^8.2|^8.3|^8.4`
- `orchestra/testbench`: add `^10.0|^11.0`
- `nunomaduro/collision`: add `^9.0`
- `nunomaduro/larastan`: add `^3.0`
- `pestphp/pest`: add `^3.7`, `pest-plugin-laravel`: add `^3.0`
- `phpstan` rules + `phpunit/phpunit`: add `^2.0` / `^11.0`
- CI: add PHP 8.4, Laravel 12/13 (testbench 10/11), `carbon ">=3.8.4"` on all rows
- CI: drop `prefer-lowest`, upgrade `actions/checkout` to v6, add `--no-coverage`
- `phpunit.xml.dist`: remove deprecated PHPUnit 10+ attributes